### PR TITLE
Add function to read a file into R directly from Synapse.

### DIFF
--- a/R/synReadFile.R
+++ b/R/synReadFile.R
@@ -1,0 +1,20 @@
+#' #' Read a file directly from Synapse into
+#' #'
+#' #' @param id Synapse ID.
+#' #' @param readfunction A function to read the file.
+#' #' @param ... Additional parameters to synGet and user defined readfunction.
+#' #' @return Results of the file reading function.
+synReadFile <- function(id, readfunction=read.csv, ...) {
+  dots <- list(...)
+
+  areSynArgs <- names(dots) %in% c("version", "downloadFile",
+                                   "downloadLocation", "ifcollision", "load")
+
+  synArgs <- c(list(id=id), dots[areSynArgs])
+  notSynArgs <- dots[!areSynArgs]
+
+  do.call(readfunction, c(synapseClient::getFileLocation(do.call(synapseClient::synGet,
+                                                                 synArgs)),
+                          notSynArgs))
+}
+


### PR DESCRIPTION
Utility function to read a file into R (with a user defined function) from Synapse (using `synGet`).

`synGet` supports `load` - suggested to @brucehoff  that maybe updating `synGet` to provide this functionality would be useful. Will look into making sure that it won't break any regression tests.
